### PR TITLE
Fix: Prevent symlink-based directory traversal attacks

### DIFF
--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -1,0 +1,183 @@
+package handler
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestReadFileWithValidPath tests reading a file in allowed directory
+func TestReadFileWithValidPath(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "filesys-integration-test-")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	testFile := filepath.Join(tmpDir, "test.txt")
+	testContent := "Hello, World!"
+	err = os.WriteFile(testFile, []byte(testContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	os.Setenv("MCP_ALLOWED_DIRS", tmpDir)
+	defer os.Unsetenv("MCP_ALLOWED_DIRS")
+
+	allowedDirsMutex.Lock()
+	allowedDirsCache = nil
+	allowedDirsMutex.Unlock()
+
+	handler := NewFileSystemHandler()
+
+	args := map[string]interface{}{
+		"path": testFile,
+	}
+
+	resp, err := handler.handleReadFile(args)
+	if err != nil {
+		t.Fatalf("Read file failed: %v", err)
+	}
+
+	if len(resp.Content) == 0 {
+		t.Fatal("No content returned")
+	}
+
+	if resp.Content[0].Text != testContent {
+		t.Errorf("Expected %q, got %q", testContent, resp.Content[0].Text)
+	}
+}
+
+// TestReadFileWithInvalidPath tests reading a file outside allowed directory
+func TestReadFileWithInvalidPath(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "filesys-integration-test-")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	allowedDir := filepath.Join(tmpDir, "allowed")
+	restrictedDir := filepath.Join(tmpDir, "restricted")
+
+	err = os.MkdirAll(allowedDir, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create allowed dir: %v", err)
+	}
+	err = os.MkdirAll(restrictedDir, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create restricted dir: %v", err)
+	}
+
+	testFile := filepath.Join(restrictedDir, "secret.txt")
+	err = os.WriteFile(testFile, []byte("secret"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	os.Setenv("MCP_ALLOWED_DIRS", allowedDir)
+	defer os.Unsetenv("MCP_ALLOWED_DIRS")
+
+	allowedDirsMutex.Lock()
+	allowedDirsCache = nil
+	allowedDirsMutex.Unlock()
+
+	handler := NewFileSystemHandler()
+
+	args := map[string]interface{}{
+		"path": testFile,
+	}
+
+	_, err = handler.handleReadFile(args)
+	if err == nil {
+		t.Fatal("Expected error when reading file outside allowed directory")
+	}
+}
+
+// TestWriteFileInAllowedDirectory tests writing to allowed directory
+func TestWriteFileInAllowedDirectory(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "filesys-integration-test-")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	os.Setenv("MCP_ALLOWED_DIRS", tmpDir)
+	defer os.Unsetenv("MCP_ALLOWED_DIRS")
+
+	allowedDirsMutex.Lock()
+	allowedDirsCache = nil
+	allowedDirsMutex.Unlock()
+
+	handler := NewFileSystemHandler()
+
+	testFile := filepath.Join(tmpDir, "newfile.txt")
+	testContent := "New content"
+
+	args := map[string]interface{}{
+		"path":    testFile,
+		"content": testContent,
+	}
+
+	_, err = handler.handleWriteFile(args)
+	if err != nil {
+		t.Fatalf("Write file failed: %v", err)
+	}
+
+	// Verify file was created
+	content, err := os.ReadFile(testFile)
+	if err != nil {
+		t.Fatalf("Failed to read created file: %v", err)
+	}
+
+	if string(content) != testContent {
+		t.Errorf("Expected %q, got %q", testContent, string(content))
+	}
+}
+
+// TestWriteFileInRestrictedDirectory tests writing to restricted directory
+func TestWriteFileInRestrictedDirectory(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "filesys-integration-test-")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	allowedDir := filepath.Join(tmpDir, "allowed")
+	restrictedDir := filepath.Join(tmpDir, "restricted")
+
+	err = os.MkdirAll(allowedDir, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create allowed dir: %v", err)
+	}
+	err = os.MkdirAll(restrictedDir, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create restricted dir: %v", err)
+	}
+
+	os.Setenv("MCP_ALLOWED_DIRS", allowedDir)
+	defer os.Unsetenv("MCP_ALLOWED_DIRS")
+
+	allowedDirsMutex.Lock()
+	allowedDirsCache = nil
+	allowedDirsMutex.Unlock()
+
+	handler := NewFileSystemHandler()
+
+	testFile := filepath.Join(restrictedDir, "newfile.txt")
+	testContent := "Should not be created"
+
+	args := map[string]interface{}{
+		"path":    testFile,
+		"content": testContent,
+	}
+
+	_, err = handler.handleWriteFile(args)
+	if err == nil {
+		t.Fatal("Expected error when writing file to restricted directory")
+	}
+
+	// Verify file was NOT created
+	if _, err := os.Stat(testFile); err == nil {
+		t.Error("File should not have been created in restricted directory")
+	}
+}

--- a/pkg/handler/utils.go
+++ b/pkg/handler/utils.go
@@ -32,7 +32,7 @@ func loadAllowedDirectories() ([]string, error) {
 	// Split by comma but preserve spaces in paths
 	dirs := strings.Split(dirsStr, ",")
 	cleanDirs := make([]string, 0, len(dirs))
-	
+
 	for _, dir := range dirs {
 		// Only trim spaces around the entire path, not within it
 		dir = strings.TrimSpace(dir)
@@ -41,16 +41,22 @@ func loadAllowedDirectories() ([]string, error) {
 		}
 
 		log.Printf("Processing directory: %q", dir)
-		
-		// Convert to absolute path (handles spaces correctly)
-		absDir, err := filepath.Abs(dir)
+
+		// Step 1: Resolve symlinks in the allowed directory itself
+		canonicalDir, err := filepath.EvalSymlinks(dir)
 		if err != nil {
-			return nil, fmt.Errorf("failed to resolve absolute path for %q: %w", dir, err)
+			return nil, fmt.Errorf("failed to resolve symlinks for %q: %w", dir, err)
 		}
-		
-		log.Printf("Absolute path: %q", absDir)
-		
-		// Verify directory exists
+
+		// Step 2: Convert to absolute path
+		absDir, err := filepath.Abs(canonicalDir)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve absolute path for %q: %w", canonicalDir, err)
+		}
+
+		log.Printf("Canonical path: %q", absDir)
+
+		// Step 3: Verify directory exists
 		info, err := os.Stat(absDir)
 		if err != nil {
 			return nil, fmt.Errorf("directory %q does not exist: %w", absDir, err)
@@ -58,7 +64,7 @@ func loadAllowedDirectories() ([]string, error) {
 		if !info.IsDir() {
 			return nil, fmt.Errorf("%q is not a directory", absDir)
 		}
-		
+
 		cleanDirs = append(cleanDirs, absDir)
 		log.Printf("Added allowed directory: %q", absDir)
 	}
@@ -99,29 +105,100 @@ func getAllowedDirs() ([]string, error) {
 	return dirs, nil
 }
 
-// isPathAllowed checks if a path is within allowed directories
+// isPathAllowed checks if a path is within allowed directories.
+//
+// Security model:
+// 1. Resolves ALL symbolic links to canonical paths using filepath.EvalSymlinks()
+// 2. Converts to absolute path
+// 3. Validates the canonical path is within allowed directories
+// 4. Uses path separator in prefix matching to prevent "/allowed" matching "/allowed_attacker"
+//
+// For non-existent paths (write operations), validates the parent directory chain.
 func (h *FileSystemHandler) isPathAllowed(path string) bool {
-	absPath, err := filepath.Abs(path)
+	// Step 1: Resolve symbolic links to get canonical path
+	canonicalPath, err := filepath.EvalSymlinks(path)
 	if err != nil {
-		log.Printf("Error resolving absolute path for %q: %v", path, err)
+		// Check if path actually exists (could be broken symlink)
+		_, statErr := os.Lstat(path)
+		if statErr != nil && os.IsNotExist(statErr) {
+			// Path truly doesn't exist - allow validation of parent for write operations
+			return h.isPathAllowedNonExistent(path)
+		}
+		// SECURITY: Block broken symlinks and other resolution errors
+		// If Lstat succeeded but EvalSymlinks failed, it's likely a broken symlink
+		log.Printf("SECURITY: Access denied to %q - symlink resolution failed: %v", path, err)
 		return false
 	}
 
-	log.Printf("Checking if path is allowed: %q", absPath)
+	// Step 2: Get absolute path (now that symlinks are resolved)
+	absPath, err := filepath.Abs(canonicalPath)
+	if err != nil {
+		log.Printf("SECURITY: Access denied to %q - absolute path resolution failed: %v", canonicalPath, err)
+		return false
+	}
+
+	log.Printf("Checking if path is allowed: %q (canonical: %q)", path, absPath)
 
 	allowedDirs, err := getAllowedDirs()
 	if err != nil {
 		log.Printf("Error getting allowed directories: %v", err)
 		return false
 	}
-	
+
+	// Step 3: Validate against allowed directories with proper path separator handling
 	for _, dir := range allowedDirs {
-		if strings.HasPrefix(absPath, dir) {
-			log.Printf("Path %q is allowed (matches prefix %q)", absPath, dir)
+		// Ensure proper prefix matching: exact match OR prefix with separator
+		if absPath == dir || strings.HasPrefix(absPath, dir+string(filepath.Separator)) {
+			log.Printf("Path %q is allowed (matches %q)", absPath, dir)
 			return true
 		}
 	}
 
-	log.Printf("Path %q is not allowed in any directory %q", absPath, allowedDirs)
+	// SECURITY: Log blocked access attempts with details
+	log.Printf("SECURITY: Access denied to %q (canonical: %q) - not in allowed directories %v", path, absPath, allowedDirs)
 	return false
+}
+
+// isPathAllowedNonExistent handles validation for paths that don't exist yet.
+// This is needed for write operations (write_file, create_directory, etc.)
+func (h *FileSystemHandler) isPathAllowedNonExistent(path string) bool {
+	// Get the parent directory and validate it exists and is allowed
+	dir := filepath.Dir(path)
+
+	// Keep going up until we find an existing directory
+	for {
+		canonicalDir, err := filepath.EvalSymlinks(dir)
+		if err == nil {
+			// Found existing parent - validate it
+			absDir, err := filepath.Abs(canonicalDir)
+			if err != nil {
+				log.Printf("Error resolving absolute path for parent %q: %v", canonicalDir, err)
+				return false
+			}
+
+			allowedDirs, err := getAllowedDirs()
+			if err != nil {
+				log.Printf("Error getting allowed directories: %v", err)
+				return false
+			}
+
+			// Check if this parent is within allowed directories
+			for _, allowedDir := range allowedDirs {
+				if absDir == allowedDir || strings.HasPrefix(absDir, allowedDir+string(filepath.Separator)) {
+					log.Printf("Non-existent path %q allowed (parent %q is within %q)", path, absDir, allowedDir)
+					return true
+				}
+			}
+			log.Printf("Non-existent path %q blocked (parent %q not in allowed directories)", path, absDir)
+			return false
+		}
+
+		// If we've reached the root, stop
+		parentDir := filepath.Dir(dir)
+		if parentDir == dir {
+			log.Printf("Non-existent path %q blocked (reached root without finding allowed parent)", path)
+			return false
+		}
+		dir = parentDir
+	}
 }

--- a/pkg/handler/utils_test.go
+++ b/pkg/handler/utils_test.go
@@ -1,0 +1,381 @@
+package handler
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// setupTestDirs creates a test directory structure with allowed and restricted areas
+func setupTestDirs(t *testing.T) (allowed string, restricted string, cleanup func()) {
+	tmpDir, err := os.MkdirTemp("", "filesys-security-test-")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+
+	allowedDir := filepath.Join(tmpDir, "allowed")
+	restrictedDir := filepath.Join(tmpDir, "restricted")
+
+	if err := os.MkdirAll(allowedDir, 0755); err != nil {
+		t.Fatalf("Failed to create allowed dir: %v", err)
+	}
+	if err := os.MkdirAll(restrictedDir, 0755); err != nil {
+		t.Fatalf("Failed to create restricted dir: %v", err)
+	}
+
+	// Create a sensitive file in restricted area
+	if err := os.WriteFile(filepath.Join(restrictedDir, "secret.txt"), []byte("sensitive data"), 0644); err != nil {
+		t.Fatalf("Failed to write secret file: %v", err)
+	}
+
+	cleanup = func() {
+		_ = os.RemoveAll(tmpDir)
+	}
+
+	return allowedDir, restrictedDir, cleanup
+}
+
+// Test 1: Symlink Attack - Direct symlink to restricted directory
+func TestSymlinkAttackToRestrictedDirectory(t *testing.T) {
+	allowed, restricted, cleanup := setupTestDirs(t)
+	defer cleanup()
+
+	// Set environment
+	os.Setenv("MCP_ALLOWED_DIRS", allowed)
+	defer os.Unsetenv("MCP_ALLOWED_DIRS")
+
+	// Clear cache to force reload
+	allowedDirsMutex.Lock()
+	allowedDirsCache = nil
+	allowedDirsMutex.Unlock()
+
+	// Create symlink in allowed directory pointing to restricted directory
+	symlinkPath := filepath.Join(allowed, "escape")
+	err := os.Symlink(restricted, symlinkPath)
+	if err != nil {
+		t.Fatalf("Failed to create symlink: %v", err)
+	}
+
+	handler := NewFileSystemHandler()
+
+	// Attempt to access restricted file through symlink
+	attackPath := filepath.Join(symlinkPath, "secret.txt")
+
+	if handler.isPathAllowed(attackPath) {
+		t.Errorf("SECURITY VULNERABILITY: Symlink attack succeeded! Path %q should be blocked", attackPath)
+	}
+}
+
+// Test 2: Symlink Attack - Nested symlinks
+func TestSymlinkAttackNested(t *testing.T) {
+	allowed, restricted, cleanup := setupTestDirs(t)
+	defer cleanup()
+
+	os.Setenv("MCP_ALLOWED_DIRS", allowed)
+	defer os.Unsetenv("MCP_ALLOWED_DIRS")
+
+	allowedDirsMutex.Lock()
+	allowedDirsCache = nil
+	allowedDirsMutex.Unlock()
+
+	// Create chain: allowed/link1 -> allowed/link2 -> restricted/
+	link1 := filepath.Join(allowed, "link1")
+	link2 := filepath.Join(allowed, "link2")
+
+	err := os.Symlink(link2, link1)
+	if err != nil {
+		t.Fatalf("Failed to create first symlink: %v", err)
+	}
+	err = os.Symlink(restricted, link2)
+	if err != nil {
+		t.Fatalf("Failed to create second symlink: %v", err)
+	}
+
+	handler := NewFileSystemHandler()
+	attackPath := filepath.Join(link1, "secret.txt")
+
+	if handler.isPathAllowed(attackPath) {
+		t.Errorf("SECURITY VULNERABILITY: Nested symlink attack succeeded!")
+	}
+}
+
+// Test 3: Legitimate symlink within allowed directory
+func TestLegitimateSymlinkWithinAllowed(t *testing.T) {
+	allowed, _, cleanup := setupTestDirs(t)
+	defer cleanup()
+
+	os.Setenv("MCP_ALLOWED_DIRS", allowed)
+	defer os.Unsetenv("MCP_ALLOWED_DIRS")
+
+	allowedDirsMutex.Lock()
+	allowedDirsCache = nil
+	allowedDirsMutex.Unlock()
+
+	// Create legitimate file and symlink within allowed directory
+	realFile := filepath.Join(allowed, "real.txt")
+	symlinkFile := filepath.Join(allowed, "link.txt")
+
+	err := os.WriteFile(realFile, []byte("legitimate data"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create real file: %v", err)
+	}
+	err = os.Symlink(realFile, symlinkFile)
+	if err != nil {
+		t.Fatalf("Failed to create symlink: %v", err)
+	}
+
+	handler := NewFileSystemHandler()
+
+	// Both should be allowed
+	if !handler.isPathAllowed(realFile) {
+		t.Errorf("Real file should be allowed: %q", realFile)
+	}
+
+	if !handler.isPathAllowed(symlinkFile) {
+		t.Errorf("Legitimate symlink within allowed directory should be allowed: %q", symlinkFile)
+	}
+}
+
+// Test 4: Path traversal with ..
+func TestPathTraversalAttack(t *testing.T) {
+	allowed, _, cleanup := setupTestDirs(t)
+	defer cleanup()
+
+	os.Setenv("MCP_ALLOWED_DIRS", allowed)
+	defer os.Unsetenv("MCP_ALLOWED_DIRS")
+
+	allowedDirsMutex.Lock()
+	allowedDirsCache = nil
+	allowedDirsMutex.Unlock()
+
+	handler := NewFileSystemHandler()
+
+	// Try to escape using ../
+	attackPath := filepath.Join(allowed, "..", "restricted", "secret.txt")
+
+	if handler.isPathAllowed(attackPath) {
+		t.Errorf("SECURITY VULNERABILITY: Path traversal attack succeeded! Path %q should be blocked", attackPath)
+	}
+}
+
+// Test 5: Non-existent file in allowed directory (write operation)
+func TestNonExistentFileInAllowedDirectory(t *testing.T) {
+	allowed, _, cleanup := setupTestDirs(t)
+	defer cleanup()
+
+	os.Setenv("MCP_ALLOWED_DIRS", allowed)
+	defer os.Unsetenv("MCP_ALLOWED_DIRS")
+
+	allowedDirsMutex.Lock()
+	allowedDirsCache = nil
+	allowedDirsMutex.Unlock()
+
+	handler := NewFileSystemHandler()
+
+	// Non-existent file in allowed directory should be allowed (for write operations)
+	newFile := filepath.Join(allowed, "newfile.txt")
+
+	if !handler.isPathAllowed(newFile) {
+		t.Errorf("Non-existent file in allowed directory should be allowed: %q", newFile)
+	}
+}
+
+// Test 6: Non-existent file in restricted area
+func TestNonExistentFileInRestrictedArea(t *testing.T) {
+	allowed, restricted, cleanup := setupTestDirs(t)
+	defer cleanup()
+
+	os.Setenv("MCP_ALLOWED_DIRS", allowed)
+	defer os.Unsetenv("MCP_ALLOWED_DIRS")
+
+	allowedDirsMutex.Lock()
+	allowedDirsCache = nil
+	allowedDirsMutex.Unlock()
+
+	handler := NewFileSystemHandler()
+
+	// Non-existent file in restricted area should be blocked
+	newFile := filepath.Join(restricted, "newfile.txt")
+
+	if handler.isPathAllowed(newFile) {
+		t.Errorf("Non-existent file in restricted directory should be blocked: %q", newFile)
+	}
+}
+
+// Test 7: Broken symlink
+func TestBrokenSymlink(t *testing.T) {
+	allowed, _, cleanup := setupTestDirs(t)
+	defer cleanup()
+
+	os.Setenv("MCP_ALLOWED_DIRS", allowed)
+	defer os.Unsetenv("MCP_ALLOWED_DIRS")
+
+	allowedDirsMutex.Lock()
+	allowedDirsCache = nil
+	allowedDirsMutex.Unlock()
+
+	// Create broken symlink
+	brokenLink := filepath.Join(allowed, "broken")
+	err := os.Symlink("/nonexistent/path", brokenLink)
+	if err != nil {
+		t.Fatalf("Failed to create broken symlink: %v", err)
+	}
+
+	handler := NewFileSystemHandler()
+
+	// Broken symlink should be blocked (can't verify target)
+	if handler.isPathAllowed(brokenLink) {
+		t.Errorf("Broken symlink should be blocked: %q", brokenLink)
+	}
+}
+
+// Test 8: Allowed directory is itself a symlink
+func TestAllowedDirectoryIsSymlink(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "filesys-security-test-")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create real directory and symlink to it
+	realDir := filepath.Join(tmpDir, "real")
+	symlinkDir := filepath.Join(tmpDir, "symlink")
+
+	err = os.MkdirAll(realDir, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create real directory: %v", err)
+	}
+	err = os.Symlink(realDir, symlinkDir)
+	if err != nil {
+		t.Fatalf("Failed to create symlink directory: %v", err)
+	}
+
+	// Create test file
+	testFile := filepath.Join(realDir, "test.txt")
+	err = os.WriteFile(testFile, []byte("test"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	// Use symlink as allowed directory
+	os.Setenv("MCP_ALLOWED_DIRS", symlinkDir)
+	defer os.Unsetenv("MCP_ALLOWED_DIRS")
+
+	allowedDirsMutex.Lock()
+	allowedDirsCache = nil
+	allowedDirsMutex.Unlock()
+
+	handler := NewFileSystemHandler()
+
+	// Should allow access to file in real directory
+	if !handler.isPathAllowed(testFile) {
+		t.Errorf("File in real directory should be allowed when allowed dir is symlink: %q", testFile)
+	}
+}
+
+// Test 9: Prefix matching edge case
+func TestPrefixMatchingEdgeCase(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "filesys-security-test-")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create directories with similar prefixes
+	allowed := filepath.Join(tmpDir, "allowed")
+	attacker := filepath.Join(tmpDir, "allowed_attacker")
+
+	err = os.MkdirAll(allowed, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create allowed directory: %v", err)
+	}
+	err = os.MkdirAll(attacker, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create attacker directory: %v", err)
+	}
+
+	err = os.WriteFile(filepath.Join(attacker, "evil.txt"), []byte("evil"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create evil file: %v", err)
+	}
+
+	os.Setenv("MCP_ALLOWED_DIRS", allowed)
+	defer os.Unsetenv("MCP_ALLOWED_DIRS")
+
+	allowedDirsMutex.Lock()
+	allowedDirsCache = nil
+	allowedDirsMutex.Unlock()
+
+	handler := NewFileSystemHandler()
+
+	// Should NOT allow access to attacker directory
+	attackPath := filepath.Join(attacker, "evil.txt")
+	if handler.isPathAllowed(attackPath) {
+		t.Errorf("SECURITY VULNERABILITY: Prefix matching allowed similar directory name: %q", attackPath)
+	}
+}
+
+// Test 10: Multiple allowed directories
+func TestMultipleAllowedDirectories(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "filesys-security-test-")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	dir1 := filepath.Join(tmpDir, "dir1")
+	dir2 := filepath.Join(tmpDir, "dir2")
+	dir3 := filepath.Join(tmpDir, "dir3")
+
+	err = os.MkdirAll(dir1, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create dir1: %v", err)
+	}
+	err = os.MkdirAll(dir2, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create dir2: %v", err)
+	}
+	err = os.MkdirAll(dir3, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create dir3: %v", err)
+	}
+
+	file1 := filepath.Join(dir1, "test1.txt")
+	file2 := filepath.Join(dir2, "test2.txt")
+	file3 := filepath.Join(dir3, "test3.txt")
+
+	err = os.WriteFile(file1, []byte("test1"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create file1: %v", err)
+	}
+	err = os.WriteFile(file2, []byte("test2"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create file2: %v", err)
+	}
+	err = os.WriteFile(file3, []byte("test3"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create file3: %v", err)
+	}
+
+	// Allow dir1 and dir2, but not dir3
+	os.Setenv("MCP_ALLOWED_DIRS", dir1+","+dir2)
+	defer os.Unsetenv("MCP_ALLOWED_DIRS")
+
+	allowedDirsMutex.Lock()
+	allowedDirsCache = nil
+	allowedDirsMutex.Unlock()
+
+	handler := NewFileSystemHandler()
+
+	if !handler.isPathAllowed(file1) {
+		t.Errorf("File in first allowed directory should be allowed: %q", file1)
+	}
+
+	if !handler.isPathAllowed(file2) {
+		t.Errorf("File in second allowed directory should be allowed: %q", file2)
+	}
+
+	if handler.isPathAllowed(file3) {
+		t.Errorf("File in non-allowed directory should be blocked: %q", file3)
+	}
+}


### PR DESCRIPTION

Fixes(Issue #7  ) a critical path validation bypass vulnerability that allowed attackers to access files outside allowed directories through symbolic links.

  ## Vulnerability Details

  **Issue**: The `isPathAllowed()` function used `filepath.Abs()` which does NOT resolve symbolic links, allowing attackers to bypass security by creating
   symlinks within allowed directories that point to restricted paths.

  **Attack Example**:
  1. Allowed directory: `/home/user/allowed`
  2. Attacker creates: `ln -s /etc/sensitive /home/user/allowed/escape`
  3. Request to read `/home/user/allowed/escape/passwd` passes validation
  4. System reads `/etc/sensitive/passwd` (outside allowed directories)

  **Impact**: All 15+ file operations were vulnerable (read, write, search, move, append, create_directory, etc.)

  ## Security Fix

  ### Core Changes

  1. **Enhanced `isPathAllowed()` function** (`utils.go:102-151`)
     - Resolves ALL symbolic links using `filepath.EvalSymlinks()` before validation
     - Validates canonical paths against allowed directories
     - Fixed prefix matching with path separator (prevents `/allowed` matching `/allowed_attacker`)
     - Blocks broken symlinks with security audit logging
     - Handles non-existent paths for write operations

  2. **Added `isPathAllowedNonExistent()` helper** (`utils.go:153-195`)
     - Validates parent directory chain for non-existent paths
     - Required for write operations (create_file, create_directory, etc.)

  3. **Updated `loadAllowedDirectories()`** (`utils.go:23-78`)
     - Resolves symlinks in allowed directories during initialization
     - Ensures consistent canonical path validation

